### PR TITLE
카카오 서비스 소개 페이지

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,6 +21,7 @@ title: 루비/레일스를 사용하는 서비스 모음
 - [잡플래닛](https://www.jobplanet.co.kr/){: .article data-tags="rails ing" }
 - [증권플러스 인사이트](http://insight.stockplus.com/){: .article data-tags="rails ing" }
 - [채팅캣](http://chattingcat.com/){: .article data-tags="rails ing" }
+- [카카오](http://www.kakao.com/){: .article data-tags="rails ing" }
 - [텀블벅](https://www.tumblbug.com/){: .article data-tags="rails ing" }
 - [파이브 락스](http://www.5rocks.io/){: .article data-tags="rails ing" }
 - [미투데이](http://me2day.net/){: .article data-tags="rails shutdown" }


### PR DESCRIPTION
카카오스토리가 레일즈로 만들어졌다는 이야기를 얼핏 들어서 빌트위드로 찍어봤는데, 카카오스토리는 정보가 잘 안나오네요.
근데 카카오 [서비스 소개 페이지](http://www.kakao.com/)는 [확실히](http://builtwith.com/?https%3a%2f%2fkakao.com%2f) 레일즈 프로젝트!
