### PR TITLE
리노트 추가.

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,7 @@ RubyWorld 루비/레일스를 사용하는 서비스를 모아둔 사이트입�
 ## [서비스 목록(운영중 + 가나다 순)](#services)
 {: #services}
 - [라인와우](http://wow.line.me/){: .article data-tags="rails ing"}
+- [리노트](http://intro.renote.me/){: .article data-tags="rails ing"}
 - [마이리얼트립](https://www.myrealtrip.com/){: .article data-tags="rails ing"}
 - [망고플레이트](http://www.mangoplate.com/){: .article data-tags="rails ing"}
 - [모아폼](http://www.moaform.com/){: .article data-tags="rails ing"}


### PR DESCRIPTION
오답노트 어플리케이션 리노트의 서버가 레일즈로 운영되고 있다고 합니다.
