### PR TITLE
add helloworld.co.kr, remove 8cruz.com

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,6 @@ RubyWorld 루비/레일스를 사용하는 서비스를 모아둔 사이트입�
 - [아이엠스쿨](http://www.iamschool.net/){: .article data-tags="rails ing" }
 - [아임8](http://www.im8.net/){: .article data-tags="rails ing" }
 - [연두](http://yeondoo.kr/){: .article data-tags="rails ing" }
-- [에이트크루즈](http://www.8cruz.com/){: .article data-tags="rails ing" }
 - [왓챠](https://watcha.net/){: .article data-tags="rails ing" }
 - [오픈칼리지](https://www.opencollege.kr/){: .article data-tags="rails ing" }
 - [유에프오팩토리](http://ufofactory.org/){: .article data-tags="rails ing" }
@@ -52,6 +51,7 @@ RubyWorld 루비/레일스를 사용하는 서비스를 모아둔 사이트입�
 - [파크 히어](http://www.parkhere.co.kr){: .article data-tags="rails ing" }
 - [판교장터](https://medium.com/n42-corp){: .article data-tags="rails ing" }
 - [해먹남녀](http://haemukja.com/){: .article data-tags="rails ing" }
+- [헬로월드](http://tryhelloworld.co.kr/){: .article data-tags="rails ing" }
 - [호텔박사](http://hotelbaksa.com/){: .article data-tags="rails ing" }
 - [라인와우](http://wow.line.me/){: .article data-tags="rails shutdown"}
 - [미투데이](http://me2day.net/){: .article data-tags="rails shutdown" }


### PR DESCRIPTION
헬로월드 : 프로그래밍 강의 사이트.

8cruz.com도 shutdown 태그를 달고 밑으로 내리려 했으나 사이트를 아예 폐쇄해버렸기때문에 지웠어요~^^;
