### PR TITLE
나우웨이팅 추가

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,10 +9,13 @@ RubyWorld 루비/레일스를 사용하는 서비스를 모아둔 사이트입�
 - 최종 수정일: {{site.time | date: "%Y-%m-%d"}}
 
 ## [서비스 목록(운영중 + 가나다 순)](#services)
+
 {: #services}
+
 - [강남역 10번 출구](http://exit10.me/){: .article data-tags="rails ing"}
 - [국민의 편지](http://assembly.email/){: .article data-tags="rails ing"}
 - [그루미](http://gurume.kr/){: .article data-tags="rails ing"}
+- [나우웨이팅](https://nowwaiting.co/){: .article data-tags="rails ing"}
 - [노일베](http://noilbe.com/){: .article data-tags="rails ing"}
 - [누구뽑지](http://whotovote.kr/){: .article data-tags="rails ing"}
 - [더누보](http://the-nuvo.com/){: .article data-tags="rails ing"}


### PR DESCRIPTION
나우웨이팅: 매장내 운영되는 웨이팅관리, 포스/키오스크, 모바일 주문 서비스 제공을 통해, 매장의 디지털전환을 돕는 서비스.

