### PR TITLE
파이브락스 삭제, 탭조이 추가

### DIFF
--- a/index.md
+++ b/index.md
@@ -63,13 +63,13 @@ RubyWorld 루비/레일스를 사용하는 서비스를 모아둔 사이트입�
 - [코드라이언](http://codelion.net){: .article data-tags="rails ing" }
 - [크리마](http://cre.ma/){: .article data-tags="rails ing backend" }
 - [클레비](https://www.clebee.net/){: .article data-tags="rails ing" }
+- [탭조이](https://www.tapjoy.com/){: .article data-tags="rails ing backend wanted" }
 - [터칭](http://www.mytouching.com/){: .article data-tags="rails ing" }
 - [텀블벅](https://www.tumblbug.com/){: .article data-tags="rails ing" }
 - [테이스트로그](https://tastelog.net/){: .article data-tags="rails ing" }
 - [토스](http://cosmiccolor.github.io/){: .article data-tags="rails ing" }
 - [투데잇](http://todait.com){: .article data-tags="rails ing backend" }([안드로이드](https://play.google.com/store/apps/details?id=com.autoschedule.proto))
 - [트라이캣치](http://www.try-cat.ch/){: .article data-tags="rails ing" }
-- [파이브 락스](http://www.5rocks.io/){: .article data-tags="rails ing" }
 - [파크 히어](http://www.parkhere.co.kr){: .article data-tags="rails ing" }
 - [당근마켓](https://medium.com/n42-corp){: .article data-tags="rails ing" }
 - [플러닝](http://flearning.net){: .article data-tags="rails ing" }


### PR DESCRIPTION
탭조이는 모바일 광고 및 앱 수익화 플랫폼입니다.

파이브락스가 탭조이에 인수된 관계로 파이브락스는 삭제하였습니다.